### PR TITLE
feat: google 로그인 구현 

### DIFF
--- a/lib/backend/sign/google.dart
+++ b/lib/backend/sign/google.dart
@@ -1,19 +1,37 @@
+import 'dart:async';
+
 import 'package:google_sign_in/google_sign_in.dart';
 
-Future<String> signInGoogle() async {
-  final GoogleSignInAccount? googleUser = await GoogleSignIn(
-      clientId: '945034348783-i72l5ioka25q7al01fe79ve1rjqenuk6.apps.googleusercontent.com'
-  ).signIn();
+const String googleClientId = '945034348783-i72l5ioka25q7al01fe79ve1rjqenuk6.apps.googleusercontent.com';
 
-  if (googleUser != null) {
-    print('name = ${googleUser.displayName}');
-    print('email = ${googleUser.email}');
+const List<String> scopes = <String>[
+  'email',
+  'https://www.googleapis.com/auth/contacts.readonly',
+];
 
-    var snapshot = await googleUser.authentication;
-    return snapshot.idToken ?? "";
-  }
+GoogleSignIn generateGoogleSignIn() {
+  GoogleSignIn googleSignIn = GoogleSignIn(
+    clientId: googleClientId,
+    scopes: scopes,
+  );
 
-  return "";
+  return googleSignIn;
+}
+
+Future<GoogleSignIn> signInGoogle() async {
+  GoogleSignIn _googleSignIn = GoogleSignIn(
+    clientId: googleClientId,
+    scopes: scopes,
+  );
+
+  _googleSignIn.onCurrentUserChanged.listen((GoogleSignInAccount? account) async {
+    var googleSignInAuthentication = await account?.authentication;
+    var idToken = googleSignInAuthentication?.idToken;
+  });
+
+  _googleSignIn.signInSilently();
+
+  return _googleSignIn;
 }
 
 Future<void> signOutGoogle() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
         '/': (context) => const Home(),
         '/post/create': (context) => const CreatePost(),
         '/login': (context) => const SignGoogle(),
-        '/google': (context) => const SignInDemo(),
+        '/google': (context) => const SignInGoogle(),
       },
       onGenerateRoute: (settings) {
         if (settings.name!.startsWith('/post')) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:client/presentation/page/comment/comments.dart';
 import 'package:client/presentation/page/home.dart';
+import 'package:client/presentation/page/login/sign_in_google.dart';
 import 'package:client/presentation/page/post/createpost.dart';
 import 'package:client/presentation/page/post/getpost.dart';
 import 'package:client/presentation/page/sign_google.dart';
@@ -19,7 +20,8 @@ class MyApp extends StatelessWidget {
       routes: {
         '/': (context) => const Home(),
         '/post/create': (context) => const CreatePost(),
-        '/login': (contenxt) => const SignGoogle(),
+        '/login': (context) => const SignGoogle(),
+        '/google': (context) => const SignInDemo(),
       },
       onGenerateRoute: (settings) {
         if (settings.name!.startsWith('/post')) {

--- a/lib/presentation/page/login/join.dart
+++ b/lib/presentation/page/login/join.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class JoinPage extends StatefulWidget {
+  final String email;
+
+  const JoinPage({
+    super.key,
+    required this.email
+  });
+
+  @override
+  _JoinPageState createState() => _JoinPageState();
+}
+
+class _JoinPageState extends State<JoinPage> {
+  String? birthDate;
+  String? country;
+  String? gender;
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Profile Page'),
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.email
+            ),
+            SizedBox(height: 16.0),
+            TextFormField(
+              decoration: InputDecoration(
+                labelText: 'Date of birth',
+              ),
+              onChanged: (value) {
+                setState(() {
+                  birthDate = value;
+                });
+              },
+            ),
+            SizedBox(height: 16.0),
+            TextFormField(
+              decoration: InputDecoration(
+                labelText: 'Country',
+              ),
+              onChanged: (value) {
+                setState(() {
+                  country = value;
+                });
+              },
+            ),
+            SizedBox(height: 16.0),
+            TextFormField(
+              decoration: InputDecoration(
+                labelText: 'Gender',
+              ),
+              onChanged: (value) {
+                setState(() {
+                  gender = value;
+                });
+              },
+            ),
+            SizedBox(height: 16.0),
+            ElevatedButton(
+              onPressed: () {
+                // 입력된 생년월일, 국가, 성별을 사용
+                if (birthDate != null && country != null && gender != null) {
+                  print('Date of Birth: ${birthDate}');
+                  print('Country: $country');
+                  print('Gender: $gender');
+                } else {
+                  print('Please fill in all fields');
+                }
+              },
+              child: Text('Submit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/page/login/sign_in_button.dart
+++ b/lib/presentation/page/login/sign_in_button.dart
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
+import 'package:google_sign_in_web/google_sign_in_web.dart' as web;
+
+typedef HandleSignInFn = Future<void> Function();
+
+Widget buildSignInButton({HandleSignInFn? onPressed}) {
+  return (GoogleSignInPlatform.instance as web.GoogleSignInPlugin).renderButton();
+}

--- a/lib/presentation/page/login/sign_in_google.dart
+++ b/lib/presentation/page/login/sign_in_google.dart
@@ -1,0 +1,230 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+import 'dart:convert' show json;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:http/http.dart' as http;
+
+import 'sign_in_button.dart';
+
+/// The scopes required by this application.
+const List<String> scopes = <String>[
+  'email',
+  'https://www.googleapis.com/auth/contacts.readonly',
+];
+
+GoogleSignIn _googleSignIn = GoogleSignIn(
+  clientId: '945034348783-i72l5ioka25q7al01fe79ve1rjqenuk6.apps.googleusercontent.com',
+  scopes: scopes,
+);
+
+/// The SignInDemo app.
+class SignInDemo extends StatefulWidget {
+  ///
+  const SignInDemo({super.key});
+
+  @override
+  State createState() => _SignInDemoState();
+}
+
+class _SignInDemoState extends State<SignInDemo> {
+  GoogleSignInAccount? _currentUser;
+  bool _isAuthorized = false; // has granted permissions?
+  String _contactText = '';
+  String _idToken = '';
+
+  @override
+  void initState() {
+    super.initState();
+
+    _googleSignIn.onCurrentUserChanged
+        .listen((GoogleSignInAccount? account) async {
+      // In mobile, being authenticated means being authorized...
+      bool isAuthorized = account != null;
+      // However, in the web...
+      if (kIsWeb && account != null) {
+        isAuthorized = await _googleSignIn.canAccessScopes(scopes);
+      }
+
+      setState(() {
+        _currentUser = account;
+        account?.authentication.then((value) => _idToken = value.idToken!);
+        _isAuthorized = isAuthorized;
+      });
+
+      // Now that we know that the user can access the required scopes, the app
+      // can call the REST API.
+      if (isAuthorized) {
+        _handleGetContact(account!);
+        // _getIdToken(account);
+      }
+    });
+
+    // In the web, _googleSignIn.signInSilently() triggers the One Tap UX.
+    //
+    // It is recommended by Google Identity Services to render both the One Tap UX
+    // and the Google Sign In button together to "reduce friction and improve
+    // sign-in rates" ([docs](https://developers.google.com/identity/gsi/web/guides/display-button#html)).
+    _googleSignIn.signInSilently();
+  }
+
+  Future<void> _getIdToken(GoogleSignInAccount user) async {
+    var googleSignInAuthentication = await user.authentication;
+    setState(() {
+      _idToken = googleSignInAuthentication.idToken!;
+    });
+  }
+
+  // Calls the People API REST endpoint for the signed-in user to retrieve information.
+  Future<void> _handleGetContact(GoogleSignInAccount user) async {
+    setState(() {
+      _contactText = 'Loading contact info...';
+    });
+    final http.Response response = await http.get(
+      Uri.parse('https://people.googleapis.com/v1/people/me/connections'
+          '?requestMask.includeField=person.names'),
+      headers: await user.authHeaders,
+    );
+    if (response.statusCode != 200) {
+      setState(() {
+        _contactText = 'People API gave a ${response.statusCode} '
+            'response. Check logs for details.';
+      });
+      print('People API ${response.statusCode} response: ${response.body}');
+      return;
+    }
+    final Map<String, dynamic> data =
+    json.decode(response.body) as Map<String, dynamic>;
+    final String? namedContact = _pickFirstNamedContact(data);
+    setState(() {
+      if (namedContact != null) {
+        _contactText = 'I see you know $namedContact!';
+      } else {
+        _contactText = 'No contacts to display.';
+      }
+    });
+  }
+
+  String? _pickFirstNamedContact(Map<String, dynamic> data) {
+    final List<dynamic>? connections = data['connections'] as List<dynamic>?;
+    final Map<String, dynamic>? contact = connections?.firstWhere(
+          (dynamic contact) => (contact as Map<Object?, dynamic>)['names'] != null,
+      orElse: () => null,
+    ) as Map<String, dynamic>?;
+    if (contact != null) {
+      final List<dynamic> names = contact['names'] as List<dynamic>;
+      final Map<String, dynamic>? name = names.firstWhere(
+            (dynamic name) =>
+        (name as Map<Object?, dynamic>)['displayName'] != null,
+        orElse: () => null,
+      ) as Map<String, dynamic>?;
+      if (name != null) {
+        return name['displayName'] as String?;
+      }
+    }
+    return null;
+  }
+
+  // This is the on-click handler for the Sign In button that is rendered by Flutter.
+  //
+  // On the web, the on-click handler of the Sign In button is owned by the JS
+  // SDK, so this method can be considered mobile only.
+  Future<void> _handleSignIn() async {
+    try {
+      await _googleSignIn.signIn();
+    } catch (error) {
+      print(error);
+    }
+  }
+
+  // Prompts the user to authorize `scopes`.
+  //
+  // This action is **required** in platforms that don't perform Authentication
+  // and Authorization at the same time (like the web).
+  //
+  // On the web, this must be called from an user interaction (button click).
+  Future<void> _handleAuthorizeScopes() async {
+    final bool isAuthorized = await _googleSignIn.requestScopes(scopes);
+    setState(() {
+      _isAuthorized = isAuthorized;
+    });
+    if (isAuthorized) {
+      _handleGetContact(_currentUser!);
+    }
+  }
+
+  Future<void> _handleSignOut() => _googleSignIn.disconnect();
+
+  Widget _buildBody() {
+    final GoogleSignInAccount? user = _currentUser;
+    if (user != null) {
+      // The user is Authenticated
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: <Widget>[
+          ListTile(
+            leading: GoogleUserCircleAvatar(
+              identity: user,
+            ),
+            title: Text(user.displayName ?? ''),
+            subtitle: Text(user.email),
+          ),
+          const Text('Signed in successfully.'),
+          if (_isAuthorized) ...<Widget>[
+            // The user has Authorized all required scopes
+            Text(_contactText),
+            ElevatedButton(
+              child: const Text('REFRESH'),
+              onPressed: () => _handleGetContact(user),
+            ),
+          ],
+          if (!_isAuthorized) ...<Widget>[
+            // The user has NOT Authorized all required scopes.
+            // (Mobile users may never see this button!)
+            const Text('Additional permissions needed to read your contacts.'),
+            ElevatedButton(
+              onPressed: _handleAuthorizeScopes,
+              child: const Text('REQUEST PERMISSIONS'),
+            ),
+          ],
+          ElevatedButton(
+            onPressed: _handleSignOut,
+            child: const Text('SIGN OUT'),
+          ),
+        ],
+      );
+    } else {
+      // The user is NOT Authenticated
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: <Widget>[
+          const Text('You are not currently signed in.'),
+          // This method is used to separate mobile from web code with conditional exports.
+          // See: src/sign_in_button.dart
+          buildSignInButton(
+            onPressed: _handleSignIn,
+          ),
+        ],
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('Google Sign In'),
+        ),
+        body: ConstrainedBox(
+          constraints: const BoxConstraints.expand(),
+          child: _buildBody(),
+        ));
+  }
+}

--- a/lib/presentation/page/login/sign_in_google.dart
+++ b/lib/presentation/page/login/sign_in_google.dart
@@ -6,9 +6,10 @@
 
 import 'dart:async';
 import 'dart:convert' show json;
+import 'dart:developer';
 
+import 'package:client/presentation/page/login/join.dart';
 import 'package:client/service/login.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
@@ -39,20 +40,20 @@ class _SignInGoogleState extends State<SignInGoogle> {
 
     loginWithGoogle.googleSignIn.onCurrentUserChanged
         .listen((GoogleSignInAccount? account) async {
-      // In mobile, being authenticated means being authorized...
       bool isAuthorized = account != null;
-      // However, in the web...
-      if (kIsWeb && account != null) {
-        isAuthorized = await loginWithGoogle.googleSignIn.canAccessScopes(scopes);
-      }
 
       setState(() {
         _isAuthorized = isAuthorized;
-      });
 
-      if (isAuthorized) {
-        _handleGetContact(account!);
-      }
+        if (isAuthorized) {
+          _handleGetContact(account!);
+          log("!!!!! logged in");
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => JoinPage(email: account.email)),
+          );
+        }
+      });
     });
   }
 

--- a/lib/presentation/page/login/sign_in_google.dart
+++ b/lib/presentation/page/login/sign_in_google.dart
@@ -20,14 +20,14 @@ const List<String> scopes = <String>[
   'https://www.googleapis.com/auth/contacts.readonly',
 ];
 
-class SignInDemo extends StatefulWidget {
-  const SignInDemo({super.key});
+class SignInGoogle extends StatefulWidget {
+  const SignInGoogle({super.key});
 
   @override
-  State createState() => _SignInDemoState();
+  State createState() => _SignInGoogleState();
 }
 
-class _SignInDemoState extends State<SignInDemo> {
+class _SignInGoogleState extends State<SignInGoogle> {
   bool _isAuthorized = false; // has granted permissions?
   String _contactText = '';
   LoginWithGoogle loginWithGoogle = LoginWithGoogle();

--- a/lib/service/login.dart
+++ b/lib/service/login.dart
@@ -1,6 +1,15 @@
 import 'package:client/backend/sign/google.dart';
 import 'package:client/backend/witb-server/login.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class LoginWithGoogle {
+  GoogleSignIn googleSignIn = generateGoogleSignIn();
+
+  Future<void> readyToSignIn() async {
+    googleSignIn.signInSilently();
+  }
+}
 
 Future<String> loginIfNotLoggedIn() async {
   final prefs = await SharedPreferences.getInstance();
@@ -11,10 +20,12 @@ Future<String> loginIfNotLoggedIn() async {
     return loggedInToken;
   }
 
-  var idToken = await signInGoogle();
+  var googleSignIn = await signInGoogle();
+  var authentication = await googleSignIn.currentUser?.authentication;
+  var idToken = authentication?.idToken;
   print("google id token: $idToken");
 
-  var witbToken = await login(LoginRequest(idToken: idToken, social: "GOOGLE"));
+  var witbToken = await login(LoginRequest(idToken: idToken!, social: "GOOGLE"));
   prefs.setString('witbToken', witbToken);
   return witbToken;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -107,13 +107,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   google_sign_in:
     dependency: "direct main"
     description:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.4"
+    version: "6.1.0"
   google_sign_in_android:
     dependency: transitive
     description:
@@ -127,21 +134,21 @@ packages:
       name: google_sign_in_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.5.1"
+    version: "5.6.2"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.2+1"
+    version: "0.12.0"
   http:
     dependency: "direct main"
     description:
@@ -204,21 +211,21 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.7"
+    version: "2.1.10"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.6"
   platform:
     dependency: transitive
     description:
@@ -232,7 +239,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   process:
     dependency: transitive
     description:
@@ -253,49 +260,49 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.17"
+    version: "2.1.1"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.15"
+    version: "2.1.4"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.2"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.1.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -349,7 +356,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -363,7 +370,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.1.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
   flex_color_scheme: ^6.1.2
-  google_sign_in: ^5.4.1
+  google_sign_in: ^6.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
구글 로그인 버전 업데이트에 대한 반영을 드디어.
로직이 완벽하진 않지만 로그인 페이지를 통해 idToken을 받아오는 로직이 완성되서 반영.

추후 로직 수정 계획

1. 구글 로그인 이후 token과 email 값을 서버로 전달. - signin
2-1. 서버에서 계정이 있는 경우 로그인 완료되고 값을 반환 (끝)
2-2. 서버에서 계정이 없는 경우 에러를 user not signed in error를 반환
2-2-1. 회원가입 페이지가 열리고 데이터를 채워서 서버로 전달 - signup


